### PR TITLE
Update for Matomo 4

### DIFF
--- a/ProtectTrackID.php
+++ b/ProtectTrackID.php
@@ -28,7 +28,7 @@ class ProtectTrackID extends \Piwik\Plugin
     public function registerEvents()
     {
         return [
-            'Piwik.getJavascriptCode' => 'hashIdJavaScript',
+            'Tracker.getJavascriptCode' => 'hashIdJavaScript',
             'SitesManager.getImageTrackingCode' => 'hashIdImage',
             'Tracker.Request.getIdSite' => 'unhashId'
         ];

--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/joubertredrat/Piwik-ProtectTrackID",
   "theme": false,
   "require": {
-    "piwik": ">=3.0.0-b1,<4.0.0-b1",
+    "piwik": ">=4.0.0-b1,<5.0.0-b1",
     "php": ">=5.4.0"
   },
   "authors": [


### PR DESCRIPTION
Seems like a simple update of altering the supported version in plugin.json as well as updating the event/action name of `piwik.getJavascriptCode` being changed to `tracker.getJavascriptCode`. Might be the only thing necessary for Matomo 4 support (definitely better than without these updates.)